### PR TITLE
fix(ci): add SUPABASE_SERVICE_ROLE_KEY to build env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
 
   security:
     name: Security Audit


### PR DESCRIPTION
The build step was missing the service role key, causing API routes to fail at build time.

Adds `SUPABASE_SERVICE_ROLE_KEY` to the build job environment.