### PR TITLE
fix(lint): exclude packages/*/dist from linting

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,8 @@ const eslintConfig = defineConfig([
     "next-env.d.ts",
     // Ignore scripts directory (CommonJS)
     "scripts/**",
+    // Ignore MCP packages (compiled JS with require())
+    "packages/**/dist/**",
   ]),
   {
     rules: {


### PR DESCRIPTION
The twitter-puppeteer-mcp package has compiled JS files that use require(), triggering ESLint errors.

Excludes `packages/**/dist/**` from linting to allow MCP packages to build.