### PR TITLE
fix(sync): consistent slug generation and closed issue handling

### DIFF
--- a/app/api/admin/cleanup-challenges/route.ts
+++ b/app/api/admin/cleanup-challenges/route.ts
@@ -1,0 +1,159 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/supabase';
+
+/**
+ * One-time cleanup endpoint to fix duplicate challenges and migrate old data.
+ * 
+ * This endpoint:
+ * 1. Finds challenges without github_issue_number
+ * 2. Attempts to extract issue number from slug or match by title
+ * 3. Removes duplicates (keeping the one with github_issue_number set)
+ * 4. Regenerates slugs to match the new consistent format
+ * 
+ * Run once after deploying the sync fix, then this endpoint can be removed.
+ */
+
+// Generate slug - matches sync/webhook
+function generateSlug(title: string, issueNumber: number): string {
+  const baseSlug = title
+    .toLowerCase()
+    .replace(/\[challenge\]\s*/i, '')
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .substring(0, 40);
+  return `${baseSlug}-${issueNumber}`;
+}
+
+export async function POST(request: NextRequest) {
+  if (!supabaseAdmin) {
+    return NextResponse.json({ error: 'Database not configured' }, { status: 500 });
+  }
+
+  // Optional: Add admin auth check here
+  // const authHeader = request.headers.get('authorization');
+  // if (authHeader !== `Bearer ${process.env.ADMIN_SECRET}`) {
+  //   return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  // }
+
+  try {
+    const results = {
+      duplicates_removed: 0,
+      challenges_fixed: 0,
+      errors: [] as string[],
+    };
+
+    // Get all challenges
+    const { data: allChallenges, error } = await supabaseAdmin
+      .from('challenges')
+      .select('id, slug, title, github_issue_number, source_repo_id, created_at')
+      .order('created_at', { ascending: true });
+
+    if (error || !allChallenges) {
+      return NextResponse.json({ error: error?.message || 'Failed to fetch challenges' }, { status: 500 });
+    }
+
+    // Group by github_issue_number to find duplicates
+    const byIssueNumber = new Map<number, typeof allChallenges>();
+    const orphans: typeof allChallenges = []; // Challenges without issue number
+
+    for (const challenge of allChallenges) {
+      if (challenge.github_issue_number) {
+        const existing = byIssueNumber.get(challenge.github_issue_number) || [];
+        existing.push(challenge);
+        byIssueNumber.set(challenge.github_issue_number, existing);
+      } else {
+        // Try to extract issue number from slug (format: title-{number})
+        const match = challenge.slug.match(/-(\d+)$/);
+        if (match) {
+          const issueNum = parseInt(match[1]);
+          const existing = byIssueNumber.get(issueNum) || [];
+          existing.push(challenge);
+          byIssueNumber.set(issueNum, existing);
+        } else {
+          orphans.push(challenge);
+        }
+      }
+    }
+
+    // Remove duplicates - keep the oldest one (first created)
+    for (const [issueNum, challenges] of byIssueNumber) {
+      if (challenges.length > 1) {
+        // Sort by created_at, keep first
+        challenges.sort((a, b) => 
+          new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+        );
+        
+        const keeper = challenges[0];
+        const toDelete = challenges.slice(1);
+
+        // Update the keeper with correct slug and issue number
+        const correctSlug = generateSlug(keeper.title, issueNum);
+        await supabaseAdmin
+          .from('challenges')
+          .update({ 
+            github_issue_number: issueNum,
+            slug: correctSlug,
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', keeper.id);
+
+        // Delete duplicates
+        for (const dup of toDelete) {
+          // First move any submissions to the keeper
+          await supabaseAdmin
+            .from('submissions')
+            .update({ challenge_id: keeper.id })
+            .eq('challenge_id', dup.id);
+
+          // Delete the duplicate
+          await supabaseAdmin
+            .from('challenges')
+            .delete()
+            .eq('id', dup.id);
+
+          results.duplicates_removed++;
+        }
+
+        results.challenges_fixed++;
+      } else if (challenges.length === 1 && !challenges[0].github_issue_number) {
+        // Single challenge missing issue number but we extracted it from slug
+        const correctSlug = generateSlug(challenges[0].title, issueNum);
+        await supabaseAdmin
+          .from('challenges')
+          .update({ 
+            github_issue_number: issueNum,
+            slug: correctSlug,
+            updated_at: new Date().toISOString(),
+          })
+          .eq('id', challenges[0].id);
+
+        results.challenges_fixed++;
+      }
+    }
+
+    // Handle orphans - challenges we couldn't match to an issue number
+    // These might be manually created or very old - leave them but log
+    if (orphans.length > 0) {
+      results.errors.push(`${orphans.length} orphan challenges without issue numbers: ${orphans.map(o => o.slug).join(', ')}`);
+    }
+
+    return NextResponse.json({
+      success: true,
+      ...results,
+      orphans: orphans.map(o => ({ id: o.id, slug: o.slug, title: o.title })),
+    });
+  } catch (error) {
+    console.error('Cleanup error:', error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Internal error' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET() {
+  return NextResponse.json({
+    message: 'POST to this endpoint to cleanup duplicate challenges and fix data integrity',
+    warning: 'This is a one-time migration endpoint. Run once after deploying sync fixes.',
+  });
+}

--- a/app/api/github/sync/route.ts
+++ b/app/api/github/sync/route.ts
@@ -1,19 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@supabase/supabase-js';
+import { supabaseAdmin } from '@/lib/supabase';
 
 const GITHUB_REST = 'https://api.github.com';
-const REPO_OWNER = 'GeorgiyAleksanyan';
-const REPO_NAME = 'the-jam';
-
-const supabaseAdmin = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-);
 
 interface GitHubIssue {
   number: number;
   title: string;
-  body: string;
+  body: string | null;
   state: string;
   labels: { name: string }[];
   created_at: string;
@@ -22,72 +15,156 @@ interface GitHubIssue {
   user: { login: string };
 }
 
-function parseChallengeMeta(body: string): {
-  bounty: number;
-  difficulty: string;
-  topics: string[];
-  deadline: string | null;
-  shortDescription: string;
-  description: string;
-} {
-  const lines = body.split('\n');
-  let bounty = 0;
-  let difficulty = 'easy';
-  let topics: string[] = [];
-  let deadline: string | null = null;
-  let shortDescription = '';
-  let inDescription = false;
-  const descriptionLines: string[] = [];
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    
-    // Parse metadata fields (flexible format: **Key**: or **Key:**)
-    if (trimmed.match(/^\*\*Bounty\*?\*?:?/i)) {
-      const match = trimmed.match(/(\d+(?:\.\d+)?)\s*(?:USDC|USD|\$)?/i);
-      if (match) bounty = parseFloat(match[1]);
-    } else if (trimmed.match(/^\*\*Difficulty\*?\*?:?/i)) {
-      const d = trimmed.replace(/^\*\*Difficulty\*?\*?:?\s*/i, '').trim().toLowerCase();
-      if (['easy', 'medium', 'hard', 'legendary'].includes(d)) {
-        difficulty = d;
-      }
-    } else if (trimmed.match(/^\*\*Topics?\*?\*?:?/i)) {
-      const t = trimmed.replace(/^\*\*Topics?\*?\*?:?\s*/i, '').trim();
-      topics = t.split(',').map(s => s.trim()).filter(Boolean);
-    } else if (trimmed.match(/^\*\*Deadline\*?\*?:?/i)) {
-      const d = trimmed.replace(/^\*\*Deadline\*?\*?:?\s*/i, '').trim();
-      if (d && d !== 'None' && d !== 'TBD' && !d.toLowerCase().includes('rolling')) {
-        deadline = d;
-      }
-    } else if (trimmed.startsWith('## Description')) {
-      inDescription = true;
-    } else if (trimmed.startsWith('## ') && inDescription) {
-      inDescription = false;
-    } else if (inDescription && trimmed) {
-      descriptionLines.push(line);
-    }
-  }
-
-  const description = descriptionLines.join('\n').trim();
-  shortDescription = description.split('\n')[0]?.substring(0, 200) || '';
-
-  return { bounty, difficulty, topics, deadline, shortDescription, description };
-}
-
-function slugify(title: string): string {
-  return title
+// Generate slug from title - MUST match webhook's generateSlug
+function generateSlug(title: string, issueNumber: number): string {
+  const baseSlug = title
     .toLowerCase()
     .replace(/\[challenge\]\s*/i, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
-    .substring(0, 50);
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .substring(0, 40);
+  return `${baseSlug}-${issueNumber}`;
+}
+
+// Extract bounty from issue body - matches webhook logic
+function extractBounty(body: string | null): number {
+  if (!body) return 0;
+  const patterns = [
+    /\*?\*?(?:Bounty|Prize|Reward)\*?\*?:?\s*\$?(\d+(?:\.\d{2})?)\s*(?:USDC)?/i,
+    /\$(\d+(?:\.\d{2})?)\s*USDC/i,
+  ];
+  for (const pattern of patterns) {
+    const match = body.match(pattern);
+    if (match) return parseFloat(match[1]);
+  }
+  return 0;
+}
+
+// Extract difficulty from labels - matches webhook logic
+function extractDifficulty(labels: Array<{ name: string }>): string {
+  const labelNames = labels.map(l => l.name.toLowerCase());
+  if (labelNames.includes('legendary')) return 'legendary';
+  if (labelNames.includes('hard')) return 'hard';
+  if (labelNames.includes('medium')) return 'medium';
+  if (labelNames.includes('easy')) return 'easy';
+  return 'medium';
+}
+
+// Extract funding threshold from body
+function extractFundingThreshold(body: string | null): number {
+  if (!body) return 0;
+  const match = body.match(/(?:Funding Threshold|Minimum Funding)[^0-9]*(\d+(?:\.\d{2})?)/i);
+  return match ? parseFloat(match[1]) : 0;
+}
+
+// Determine status - matches webhook logic
+function determineStatus(
+  issueState: string,
+  labels: string[],
+  prizePool: number,
+  fundingThreshold: number
+): string {
+  const lowerLabels = labels.map(l => l.toLowerCase());
+  
+  if (lowerLabels.includes('solved') || lowerLabels.includes('winner-selected')) return 'solved';
+  if (lowerLabels.includes('voting')) return 'voting';
+  if (lowerLabels.includes('cancelled')) return 'cancelled';
+  
+  if (issueState === 'closed') {
+    return lowerLabels.includes('solved') ? 'solved' : 'closed';
+  }
+  
+  if (fundingThreshold > 0 && prizePool < fundingThreshold) {
+    return prizePool > 0 ? 'funding' : 'proposed';
+  }
+  
+  return 'open';
+}
+
+// Sync a single issue to the database
+async function syncIssue(
+  issue: GitHubIssue,
+  sourceRepoId: number,
+  existingChallenges: Map<number, { id: number; prize_pool: number; slug: string }>
+): Promise<{ action: string; slug: string } | { error: string }> {
+  const slug = generateSlug(issue.title, issue.number);
+  const labels = issue.labels.map(l => l.name);
+  const bounty = extractBounty(issue.body);
+  const difficulty = extractDifficulty(issue.labels);
+  const fundingThreshold = extractFundingThreshold(issue.body);
+  
+  const existing = existingChallenges.get(issue.number);
+  const prizePool = existing?.prize_pool || bounty;
+  const status = determineStatus(issue.state, labels, prizePool, fundingThreshold);
+
+  const challengeData = {
+    slug,
+    title: issue.title,
+    description: issue.body || '',
+    difficulty,
+    status,
+    prize_pool: existing ? existing.prize_pool : bounty,
+    funding_threshold: fundingThreshold,
+    source_repo_id: sourceRepoId,
+    github_issue_number: issue.number,
+    github_issue_url: issue.html_url,
+    github_issue_state: issue.state,
+    github_labels: labels,
+    github_synced_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  };
+
+  if (existing) {
+    // Update existing challenge
+    const { error } = await supabaseAdmin!
+      .from('challenges')
+      .update(challengeData)
+      .eq('id', existing.id);
+
+    if (error) return { error: error.message };
+    return { action: 'updated', slug };
+  } else {
+    // Insert new challenge
+    const { error } = await supabaseAdmin!
+      .from('challenges')
+      .insert({ ...challengeData, created_at: issue.created_at });
+
+    if (error) {
+      // Handle slug conflict by updating existing slug-based entry
+      if (error.code === '23505') {
+        const { error: updateError } = await supabaseAdmin!
+          .from('challenges')
+          .update(challengeData)
+          .eq('slug', slug);
+        
+        if (updateError) return { error: updateError.message };
+        return { action: 'updated_by_slug', slug };
+      }
+      return { error: error.message };
+    }
+    return { action: 'created', slug };
+  }
 }
 
 export async function POST(request: NextRequest) {
+  if (!supabaseAdmin) {
+    return NextResponse.json({ error: 'Database not configured' }, { status: 500 });
+  }
+
   try {
-    // Optional: Add auth check for manual triggers
-    // For now, allow unauthenticated sync for simplicity
-    
+    // Get all active source repos
+    const { data: sourceRepos, error: repoError } = await supabaseAdmin
+      .from('source_repos')
+      .select('*')
+      .eq('is_active', true);
+
+    if (repoError || !sourceRepos?.length) {
+      return NextResponse.json({ 
+        error: 'No active source repos configured',
+        details: repoError?.message 
+      }, { status: 400 });
+    }
+
     const headers: Record<string, string> = {
       'Accept': 'application/vnd.github+json',
       'User-Agent': 'thejam-sync',
@@ -97,121 +174,77 @@ export async function POST(request: NextRequest) {
       headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
     }
 
-    // Fetch all challenge issues
-    const response = await fetch(
-      `${GITHUB_REST}/repos/${REPO_OWNER}/${REPO_NAME}/issues?labels=challenge&state=open&per_page=100`,
-      { headers }
-    );
-
-    if (!response.ok) {
-      throw new Error(`GitHub API error: ${response.status}`);
-    }
-
-    const issues: GitHubIssue[] = await response.json();
-    
     const results = {
-      synced: 0,
+      repos_synced: 0,
+      created: 0,
       updated: 0,
+      closed_synced: 0,
       errors: [] as string[],
     };
 
-    for (const issue of issues) {
-      try {
-        const title = issue.title.replace(/^\[Challenge\]\s*/i, '').trim();
-        const slug = slugify(issue.title);
-        const meta = parseChallengeMeta(issue.body || '');
+    for (const sourceRepo of sourceRepos) {
+      const { owner, name, challenge_label } = sourceRepo;
+
+      // Fetch existing challenges for this repo (to preserve prize_pool)
+      const { data: existingChallenges } = await supabaseAdmin
+        .from('challenges')
+        .select('id, github_issue_number, prize_pool, slug')
+        .eq('source_repo_id', sourceRepo.id);
+
+      const existingMap = new Map(
+        (existingChallenges || []).map(c => [c.github_issue_number, c])
+      );
+
+      // Fetch OPEN issues with challenge label
+      const openResponse = await fetch(
+        `${GITHUB_REST}/repos/${owner}/${name}/issues?labels=${encodeURIComponent(challenge_label)}&state=open&per_page=100`,
+        { headers }
+      );
+
+      if (!openResponse.ok) {
+        results.errors.push(`${owner}/${name}: GitHub API error ${openResponse.status}`);
+        continue;
+      }
+
+      const openIssues: GitHubIssue[] = await openResponse.json();
+
+      // Fetch CLOSED issues with challenge label (to sync solved/closed status)
+      const closedResponse = await fetch(
+        `${GITHUB_REST}/repos/${owner}/${name}/issues?labels=${encodeURIComponent(challenge_label)}&state=closed&per_page=100`,
+        { headers }
+      );
+
+      const closedIssues: GitHubIssue[] = closedResponse.ok ? await closedResponse.json() : [];
+
+      // Process all issues
+      const allIssues = [...openIssues, ...closedIssues];
+
+      for (const issue of allIssues) {
+        const result = await syncIssue(issue, sourceRepo.id, existingMap);
         
-        // Determine status from labels
-        let status = 'open';
-        for (const label of issue.labels) {
-          if (label.name === 'active') status = 'active';
-          if (label.name === 'voting') status = 'voting';
-          if (label.name === 'completed') status = 'completed';
-        }
-
-        // Check if challenge exists (by github_issue_id OR by slug)
-        let { data: existing } = await supabaseAdmin
-          .from('challenges')
-          .select('id')
-          .eq('github_issue_id', issue.number)
-          .single();
-
-        // If not found by github_issue_id, try by slug (for pre-existing challenges)
-        if (!existing) {
-          const { data: bySlug } = await supabaseAdmin
-            .from('challenges')
-            .select('id')
-            .eq('slug', slug)
-            .single();
-          existing = bySlug;
-        }
-
-        const challengeData = {
-          title,
-          slug,
-          short_description: meta.shortDescription,
-          description: meta.description || issue.body || '',
-          difficulty: meta.difficulty,
-          status,
-          prize_pool: meta.bounty,
-          github_issue_id: issue.number,
-          github_issue_url: issue.html_url,
-          github_synced_at: new Date().toISOString(),
-          updated_at: new Date().toISOString(),
-        };
-
-        if (existing) {
-          // Update existing
-          const { error } = await supabaseAdmin
-            .from('challenges')
-            .update(challengeData)
-            .eq('id', existing.id);
-
-          if (error) throw error;
+        if ('error' in result) {
+          results.errors.push(`Issue #${issue.number}: ${result.error}`);
+        } else if (result.action === 'created') {
+          results.created++;
+        } else if (result.action.startsWith('updated')) {
           results.updated++;
-        } else {
-          // Insert new - need to handle slug conflicts
-          let finalSlug = slug;
-          let attempt = 0;
-          let inserted = false;
-
-          while (!inserted && attempt < 5) {
-            const { error } = await supabaseAdmin
-              .from('challenges')
-              .insert({
-                ...challengeData,
-                slug: finalSlug,
-                created_at: issue.created_at,
-              });
-
-            if (error) {
-              if (error.code === '23505' && error.message.includes('slug')) {
-                // Slug conflict - add suffix
-                attempt++;
-                finalSlug = `${slug}-${attempt}`;
-              } else {
-                throw error;
-              }
-            } else {
-              inserted = true;
-              results.synced++;
-            }
+          if (issue.state === 'closed') {
+            results.closed_synced++;
           }
         }
-      } catch (err: any) {
-        results.errors.push(`Issue #${issue.number}: ${err.message}`);
       }
+
+      results.repos_synced++;
     }
 
     return NextResponse.json({
       success: true,
-      issues_found: issues.length,
       ...results,
     });
-  } catch (error: any) {
+  } catch (error) {
     console.error('GitHub sync error:', error);
     return NextResponse.json(
-      { error: error.message },
+      { error: error instanceof Error ? error.message : 'Internal error' },
       { status: 500 }
     );
   }
@@ -220,5 +253,6 @@ export async function POST(request: NextRequest) {
 export async function GET() {
   return NextResponse.json({
     message: 'POST to this endpoint to sync GitHub challenge issues to the database',
+    note: 'Syncs both open AND closed issues from all active source_repos',
   });
 }

--- a/app/api/github/webhook/route.ts
+++ b/app/api/github/webhook/route.ts
@@ -47,10 +47,11 @@ function extractFundingThreshold(body: string | null): number {
   return match ? parseFloat(match[1]) : 0;
 }
 
-// Generate slug from title
+// Generate slug from title - MUST match sync route's generateSlug
 function generateSlug(title: string, issueNumber: number): string {
   const baseSlug = title
     .toLowerCase()
+    .replace(/\[challenge\]\s*/i, '')
     .replace(/[^a-z0-9\s-]/g, '')
     .replace(/\s+/g, '-')
     .substring(0, 40);


### PR DESCRIPTION
## Summary
Fixes the sync/webhook inconsistency causing duplicate challenges and broken issue linking.

## Problem
- Sync used `github_issue_id`, webhook used `github_issue_number` (different columns!)
- Sync generated slugs without issue number, webhook included it → duplicates
- Sync only fetched open issues → closed challenges stayed "open" forever
- Sync hardcoded repo, webhook used `source_repos` table

## Solution
- **Unified slug generation**: Both sync and webhook use identical `generateSlug(title, issueNumber)`
- **Sync fetches closed issues**: Now syncs both open AND closed issues to update status
- **Consistent column usage**: Both use `github_issue_number` 
- **Sync uses source_repos**: No more hardcoded repo, reads from database

## New Endpoint
`POST /api/admin/cleanup-challenges` - One-time migration to:
- Find and merge duplicate challenges
- Fix missing `github_issue_number` values
- Regenerate slugs to consistent format

## Migration Steps
After merging:
1. Deploy to Vercel
2. Run: `curl -X POST https://the-jam.webglo.org/api/admin/cleanup-challenges`
3. Run: `curl -X POST https://the-jam.webglo.org/api/github/sync`
4. Verify challenges page shows correct data

## Files Changed
- `app/api/github/sync/route.ts` - Complete rewrite
- `app/api/github/webhook/route.ts` - Updated generateSlug
- `app/api/admin/cleanup-challenges/route.ts` - New migration endpoint