### PR TITLE
fix(cleanup): match orphan challenges to GitHub issues by title

### DIFF
--- a/app/api/admin/cleanup-challenges/route.ts
+++ b/app/api/admin/cleanup-challenges/route.ts
@@ -5,13 +5,16 @@ import { supabaseAdmin } from '@/lib/supabase';
  * One-time cleanup endpoint to fix duplicate challenges and migrate old data.
  * 
  * This endpoint:
- * 1. Finds challenges without github_issue_number
- * 2. Attempts to extract issue number from slug or match by title
- * 3. Removes duplicates (keeping the one with github_issue_number set)
- * 4. Regenerates slugs to match the new consistent format
+ * 1. Fetches all GitHub challenge issues to build title -> issue mapping
+ * 2. Finds challenges without github_issue_number
+ * 3. Matches them to GitHub issues by normalized title
+ * 4. Updates with correct github_issue_number and slug
+ * 5. Removes duplicates (keeping oldest, moving submissions)
  * 
- * Run once after deploying the sync fix, then this endpoint can be removed.
+ * Run once after deploying the sync fix.
  */
+
+const GITHUB_REST = 'https://api.github.com';
 
 // Generate slug - matches sync/webhook
 function generateSlug(title: string, issueNumber: number): string {
@@ -24,123 +27,180 @@ function generateSlug(title: string, issueNumber: number): string {
   return `${baseSlug}-${issueNumber}`;
 }
 
+// Normalize title for matching
+function normalizeTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/\[challenge\]\s*/i, '')
+    .replace(/[^a-z0-9]/g, '')
+    .trim();
+}
+
 export async function POST(request: NextRequest) {
   if (!supabaseAdmin) {
     return NextResponse.json({ error: 'Database not configured' }, { status: 500 });
   }
 
-  // Optional: Add admin auth check here
-  // const authHeader = request.headers.get('authorization');
-  // if (authHeader !== `Bearer ${process.env.ADMIN_SECRET}`) {
-  //   return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  // }
-
   try {
     const results = {
+      orphans_matched: 0,
       duplicates_removed: 0,
-      challenges_fixed: 0,
+      challenges_updated: 0,
       errors: [] as string[],
     };
 
+    // Fetch GitHub issues to build title -> issue number map
+    const headers: Record<string, string> = {
+      'Accept': 'application/vnd.github+json',
+      'User-Agent': 'thejam-cleanup',
+    };
+    if (process.env.GITHUB_TOKEN) {
+      headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
+    }
+
+    // Get source repos
+    const { data: sourceRepos } = await supabaseAdmin
+      .from('source_repos')
+      .select('*')
+      .eq('is_active', true);
+
+    if (!sourceRepos?.length) {
+      return NextResponse.json({ error: 'No active source repos' }, { status: 400 });
+    }
+
+    // Build title -> issue mapping from all repos
+    const titleToIssue = new Map<string, { number: number; state: string; sourceRepoId: number; title: string }>();
+
+    for (const repo of sourceRepos) {
+      // Fetch both open and closed issues
+      for (const state of ['open', 'closed']) {
+        const response = await fetch(
+          `${GITHUB_REST}/repos/${repo.owner}/${repo.name}/issues?labels=${encodeURIComponent(repo.challenge_label)}&state=${state}&per_page=100`,
+          { headers }
+        );
+        if (response.ok) {
+          const issues = await response.json();
+          for (const issue of issues) {
+            const normalizedTitle = normalizeTitle(issue.title);
+            titleToIssue.set(normalizedTitle, {
+              number: issue.number,
+              state: issue.state,
+              sourceRepoId: repo.id,
+              title: issue.title,
+            });
+          }
+        }
+      }
+    }
+
     // Get all challenges
-    const { data: allChallenges, error } = await supabaseAdmin
+    const { data: allChallenges } = await supabaseAdmin
       .from('challenges')
       .select('id, slug, title, github_issue_number, source_repo_id, created_at')
       .order('created_at', { ascending: true });
 
-    if (error || !allChallenges) {
-      return NextResponse.json({ error: error?.message || 'Failed to fetch challenges' }, { status: 500 });
+    if (!allChallenges) {
+      return NextResponse.json({ error: 'Failed to fetch challenges' }, { status: 500 });
     }
 
-    // Group by github_issue_number to find duplicates
-    const byIssueNumber = new Map<number, typeof allChallenges>();
-    const orphans: typeof allChallenges = []; // Challenges without issue number
-
+    // Group challenges by normalized title
+    const byTitle = new Map<string, typeof allChallenges>();
     for (const challenge of allChallenges) {
-      if (challenge.github_issue_number) {
-        const existing = byIssueNumber.get(challenge.github_issue_number) || [];
-        existing.push(challenge);
-        byIssueNumber.set(challenge.github_issue_number, existing);
-      } else {
-        // Try to extract issue number from slug (format: title-{number})
-        const match = challenge.slug.match(/-(\d+)$/);
-        if (match) {
-          const issueNum = parseInt(match[1]);
-          const existing = byIssueNumber.get(issueNum) || [];
-          existing.push(challenge);
-          byIssueNumber.set(issueNum, existing);
-        } else {
-          orphans.push(challenge);
-        }
-      }
+      const normalized = normalizeTitle(challenge.title);
+      const existing = byTitle.get(normalized) || [];
+      existing.push(challenge);
+      byTitle.set(normalized, existing);
     }
 
-    // Remove duplicates - keep the oldest one (first created)
-    for (const [issueNum, challenges] of byIssueNumber) {
-      if (challenges.length > 1) {
-        // Sort by created_at, keep first
-        challenges.sort((a, b) => 
-          new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
-        );
-        
-        const keeper = challenges[0];
-        const toDelete = challenges.slice(1);
+    // Process each group
+    for (const [normalizedTitle, challenges] of byTitle) {
+      const issueInfo = titleToIssue.get(normalizedTitle);
+      
+      if (!issueInfo) {
+        // No matching GitHub issue - these might be manually created or deleted
+        if (challenges.some(c => !c.github_issue_number)) {
+          results.errors.push(`No GitHub issue found for: ${challenges[0].title}`);
+        }
+        continue;
+      }
 
-        // Update the keeper with correct slug and issue number
-        const correctSlug = generateSlug(keeper.title, issueNum);
-        await supabaseAdmin
-          .from('challenges')
-          .update({ 
-            github_issue_number: issueNum,
-            slug: correctSlug,
-            updated_at: new Date().toISOString(),
-          })
-          .eq('id', keeper.id);
+      // Find the best challenge to keep (one with github_issue_number set, or oldest)
+      let keeper = challenges.find(c => c.github_issue_number === issueInfo.number);
+      if (!keeper) {
+        keeper = challenges[0]; // Keep oldest
+      }
 
-        // Delete duplicates
-        for (const dup of toDelete) {
-          // First move any submissions to the keeper
+      const correctSlug = generateSlug(issueInfo.title, issueInfo.number);
+
+      // First, delete any other entries that would conflict with the new slug
+      const { data: conflicting } = await supabaseAdmin
+        .from('challenges')
+        .select('id')
+        .eq('slug', correctSlug)
+        .neq('id', keeper.id);
+
+      if (conflicting?.length) {
+        for (const conflict of conflicting) {
+          // Move submissions first
           await supabaseAdmin
             .from('submissions')
             .update({ challenge_id: keeper.id })
-            .eq('challenge_id', dup.id);
-
-          // Delete the duplicate
+            .eq('challenge_id', conflict.id);
+          
+          // Delete conflicting entry
           await supabaseAdmin
             .from('challenges')
             .delete()
-            .eq('id', dup.id);
-
+            .eq('id', conflict.id);
+          
           results.duplicates_removed++;
         }
+      }
 
-        results.challenges_fixed++;
-      } else if (challenges.length === 1 && !challenges[0].github_issue_number) {
-        // Single challenge missing issue number but we extracted it from slug
-        const correctSlug = generateSlug(challenges[0].title, issueNum);
+      // Update the keeper with correct data
+      const { error: updateError } = await supabaseAdmin
+        .from('challenges')
+        .update({
+          github_issue_number: issueInfo.number,
+          source_repo_id: issueInfo.sourceRepoId,
+          slug: correctSlug,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', keeper.id);
+
+      if (updateError) {
+        results.errors.push(`Failed to update ${keeper.title}: ${updateError.message}`);
+        continue;
+      }
+
+      if (!keeper.github_issue_number) {
+        results.orphans_matched++;
+      }
+      results.challenges_updated++;
+
+      // Delete remaining duplicates (same normalized title but different entries)
+      const toDelete = challenges.filter(c => c.id !== keeper.id);
+      for (const dup of toDelete) {
+        // Move submissions to keeper
+        await supabaseAdmin
+          .from('submissions')
+          .update({ challenge_id: keeper.id })
+          .eq('challenge_id', dup.id);
+
+        // Delete duplicate
         await supabaseAdmin
           .from('challenges')
-          .update({ 
-            github_issue_number: issueNum,
-            slug: correctSlug,
-            updated_at: new Date().toISOString(),
-          })
-          .eq('id', challenges[0].id);
+          .delete()
+          .eq('id', dup.id);
 
-        results.challenges_fixed++;
+        results.duplicates_removed++;
       }
-    }
-
-    // Handle orphans - challenges we couldn't match to an issue number
-    // These might be manually created or very old - leave them but log
-    if (orphans.length > 0) {
-      results.errors.push(`${orphans.length} orphan challenges without issue numbers: ${orphans.map(o => o.slug).join(', ')}`);
     }
 
     return NextResponse.json({
       success: true,
       ...results,
-      orphans: orphans.map(o => ({ id: o.id, slug: o.slug, title: o.title })),
+      github_issues_found: titleToIssue.size,
     });
   } catch (error) {
     console.error('Cleanup error:', error);
@@ -154,6 +214,6 @@ export async function POST(request: NextRequest) {
 export async function GET() {
   return NextResponse.json({
     message: 'POST to this endpoint to cleanup duplicate challenges and fix data integrity',
-    warning: 'This is a one-time migration endpoint. Run once after deploying sync fixes.',
+    warning: 'This is a one-time migration endpoint. Matches challenges to GitHub issues by title.',
   });
 }


### PR DESCRIPTION
## Problem
The cleanup script from PR #24 matched by slug suffix, but old challenges have slugs like `array-flattener` (no issue number), so they couldn't be matched.

## Solution
Rewrote the cleanup to:
1. Fetch ALL GitHub issues with challenge label (open + closed)
2. Build a normalized title → issue number map
3. Match existing challenges by title instead of slug
4. Update matched challenges with correct `github_issue_number` and new slug format
5. Remove duplicates, moving submissions to the keeper

## After Deploy
Run:
```bash
curl -X POST https://the-jam.webglo.org/api/admin/cleanup-challenges
```

This will:
- Link 9 orphan challenges to their GitHub issues
- Remove ~6 duplicate entries
- Update all slugs to consistent format (`title-{issue_number}`)