### PR TITLE
feat(mcp): Add SMS texting tools to thejam-mcp

### DIFF
--- a/packages/thejam-mcp/dist/api.d.ts
+++ b/packages/thejam-mcp/dist/api.d.ts
@@ -172,4 +172,92 @@ export declare class JamApiClient {
         avatar_url?: string;
         source: 'agent' | 'github';
     }[]>;
+    /**
+     * Initiate phone pairing
+     */
+    pairPhone(phone: string, carrier: string): Promise<{
+        success: boolean;
+        message: string;
+        gateway_email: string;
+        verification_code: string;
+        expires_at: string;
+        instructions: string;
+    }>;
+    /**
+     * Get current phone pairing status
+     */
+    getPhonePairing(): Promise<{
+        paired: boolean;
+        phone?: string;
+        carrier?: string;
+        gateway_email?: string;
+        last_outbound?: string;
+        last_inbound?: string;
+        messages_today?: number;
+        paused?: boolean;
+        pause_reason?: string;
+        rate_limits?: {
+            MESSAGES_PER_HOUR: number;
+            MESSAGES_PER_DAY: number;
+            MAX_MESSAGE_LENGTH: number;
+        };
+    }>;
+    /**
+     * Remove phone pairing
+     */
+    unpairPhone(): Promise<{
+        success: boolean;
+        message: string;
+    }>;
+    /**
+     * Verify phone with code
+     */
+    verifyPhone(code: string): Promise<{
+        success: boolean;
+        message: string;
+        phone?: string;
+        gateway_email?: string;
+    }>;
+    /**
+     * Send a text message (validates rate limits, returns gog command)
+     */
+    sendText(message: string): Promise<{
+        success: boolean;
+        gateway_email: string;
+        message_length: number;
+        warning?: string;
+        remaining: {
+            hourly: number;
+            daily: number;
+        };
+        instructions: string;
+    }>;
+    /**
+     * Get text message history
+     */
+    getTexts(options?: {
+        since?: string;
+        limit?: number;
+        direction?: 'inbound' | 'outbound' | 'all';
+    }): Promise<{
+        phone: string;
+        gateway_email: string;
+        messages: Array<{
+            id: string;
+            direction: 'inbound' | 'outbound';
+            content: string;
+            created_at: string;
+        }>;
+        count: number;
+        since: string;
+    }>;
+    /**
+     * Record an inbound text message (from Gmail polling)
+     */
+    recordInboundText(content: string, gmailMessageId?: string): Promise<{
+        success: boolean;
+        duplicate?: boolean;
+        message: string;
+        unpaused?: boolean;
+    }>;
 }

--- a/packages/thejam-mcp/dist/api.js
+++ b/packages/thejam-mcp/dist/api.js
@@ -180,4 +180,58 @@ export class JamApiClient {
     async searchMentions(query) {
         return this.request('GET', `/api/mentions?q=${encodeURIComponent(query)}`);
     }
+    // ============ Texting/SMS Bridge ============
+    /**
+     * Initiate phone pairing
+     */
+    async pairPhone(phone, carrier) {
+        return this.request('POST', '/api/texting/pair', { phone, carrier });
+    }
+    /**
+     * Get current phone pairing status
+     */
+    async getPhonePairing() {
+        return this.request('GET', '/api/texting/pair');
+    }
+    /**
+     * Remove phone pairing
+     */
+    async unpairPhone() {
+        return this.request('DELETE', '/api/texting/pair');
+    }
+    /**
+     * Verify phone with code
+     */
+    async verifyPhone(code) {
+        return this.request('POST', '/api/texting/verify', { code });
+    }
+    /**
+     * Send a text message (validates rate limits, returns gog command)
+     */
+    async sendText(message) {
+        return this.request('POST', '/api/texting/send', { message });
+    }
+    /**
+     * Get text message history
+     */
+    async getTexts(options) {
+        const params = new URLSearchParams();
+        if (options?.since)
+            params.set('since', options.since);
+        if (options?.limit)
+            params.set('limit', options.limit.toString());
+        if (options?.direction)
+            params.set('direction', options.direction);
+        const query = params.toString();
+        return this.request('GET', `/api/texting/messages${query ? `?${query}` : ''}`);
+    }
+    /**
+     * Record an inbound text message (from Gmail polling)
+     */
+    async recordInboundText(content, gmailMessageId) {
+        return this.request('POST', '/api/texting/messages', {
+            content,
+            gmail_message_id: gmailMessageId,
+        });
+    }
 }

--- a/packages/thejam-mcp/dist/index.d.ts
+++ b/packages/thejam-mcp/dist/index.d.ts
@@ -6,7 +6,7 @@
  * via the Model Context Protocol (MCP).
  *
  * Configuration via environment variables:
- *   THEJAM_API_URL - Base URL (default: https://the-jam-delta.vercel.app)
+ *   THEJAM_API_URL - Base URL (default: https://the-jam.webglo.org)
  *   THEJAM_API_KEY - API key for authenticated requests
  */
 export {};

--- a/packages/thejam-mcp/dist/index.js
+++ b/packages/thejam-mcp/dist/index.js
@@ -6,7 +6,7 @@
  * via the Model Context Protocol (MCP).
  *
  * Configuration via environment variables:
- *   THEJAM_API_URL - Base URL (default: https://the-jam-delta.vercel.app)
+ *   THEJAM_API_URL - Base URL (default: https://the-jam.webglo.org)
  *   THEJAM_API_KEY - API key for authenticated requests
  */
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
@@ -14,7 +14,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { CallToolRequestSchema, ListToolsRequestSchema, } from '@modelcontextprotocol/sdk/types.js';
 import { JamApiClient } from './api.js';
 // Configuration
-const API_URL = process.env.THEJAM_API_URL || 'https://the-jam-delta.vercel.app';
+const API_URL = process.env.THEJAM_API_URL || 'https://the-jam.webglo.org';
 const API_KEY = process.env.THEJAM_API_KEY;
 // Initialize API client
 const client = new JamApiClient({
@@ -294,6 +294,109 @@ const tools = [
                 },
             },
             required: ['query'],
+        },
+    },
+    // ============ Texting/SMS Tools ============
+    {
+        name: 'pair_phone',
+        description: 'Pair a phone number for SMS texting. Uses free carrier email-to-SMS gateways. Supported carriers: tmobile, att, verizon, sprint, googlefi, cricket, metro, boost, mint, visible, uscellular.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                phone: {
+                    type: 'string',
+                    description: 'Phone number (10-digit US number, e.g., "+1 555 123 4567" or "5551234567")',
+                },
+                carrier: {
+                    type: 'string',
+                    description: 'Mobile carrier (tmobile, att, verizon, sprint, googlefi, etc)',
+                },
+            },
+            required: ['phone', 'carrier'],
+        },
+    },
+    {
+        name: 'verify_phone',
+        description: 'Complete phone pairing by entering the verification code sent via SMS.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                code: {
+                    type: 'string',
+                    description: 'The 6-digit verification code received via SMS',
+                },
+            },
+            required: ['code'],
+        },
+    },
+    {
+        name: 'texting_status',
+        description: 'Check current phone pairing status and rate limits.',
+        inputSchema: {
+            type: 'object',
+            properties: {},
+        },
+    },
+    {
+        name: 'send_text',
+        description: 'Send an SMS text message to the paired phone number. Returns the gog command to execute.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                message: {
+                    type: 'string',
+                    description: 'The message to send (keep under 160 chars for single SMS)',
+                },
+            },
+            required: ['message'],
+        },
+    },
+    {
+        name: 'get_texts',
+        description: 'Get text message history (sent and received).',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                since: {
+                    type: 'string',
+                    description: 'Time range (e.g., "1h", "24h", "7d" or ISO timestamp)',
+                },
+                limit: {
+                    type: 'number',
+                    description: 'Maximum messages to return (default: 50)',
+                },
+                direction: {
+                    type: 'string',
+                    enum: ['inbound', 'outbound', 'all'],
+                    description: 'Filter by direction (default: all)',
+                },
+            },
+        },
+    },
+    {
+        name: 'record_inbound_text',
+        description: 'Record an inbound text message after polling Gmail. Helps track conversation and unpauses if paused.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                content: {
+                    type: 'string',
+                    description: 'The message content from the inbound SMS',
+                },
+                gmail_message_id: {
+                    type: 'string',
+                    description: 'Gmail message ID for deduplication',
+                },
+            },
+            required: ['content'],
+        },
+    },
+    {
+        name: 'unpair_phone',
+        description: 'Remove the current phone pairing.',
+        inputSchema: {
+            type: 'object',
+            properties: {},
         },
     },
 ];
@@ -624,6 +727,182 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                         {
                             type: 'text',
                             text: JSON.stringify(results, null, 2),
+                        },
+                    ],
+                };
+            }
+            // ============ Texting/SMS Handlers ============
+            case 'pair_phone': {
+                if (!API_KEY) {
+                    return {
+                        content: [
+                            {
+                                type: 'text',
+                                text: 'Error: API key required for texting. Set THEJAM_API_KEY environment variable.',
+                            },
+                        ],
+                        isError: true,
+                    };
+                }
+                const phone = args?.phone;
+                const carrier = args?.carrier;
+                if (!phone || !carrier) {
+                    throw new Error('Missing required parameters: phone and carrier');
+                }
+                const result = await client.pairPhone(phone, carrier);
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: JSON.stringify(result, null, 2),
+                        },
+                    ],
+                };
+            }
+            case 'verify_phone': {
+                if (!API_KEY) {
+                    return {
+                        content: [
+                            {
+                                type: 'text',
+                                text: 'Error: API key required for texting. Set THEJAM_API_KEY environment variable.',
+                            },
+                        ],
+                        isError: true,
+                    };
+                }
+                const code = args?.code;
+                if (!code) {
+                    throw new Error('Missing required parameter: code');
+                }
+                const result = await client.verifyPhone(code);
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: JSON.stringify(result, null, 2),
+                        },
+                    ],
+                };
+            }
+            case 'texting_status': {
+                if (!API_KEY) {
+                    return {
+                        content: [
+                            {
+                                type: 'text',
+                                text: 'Error: API key required for texting. Set THEJAM_API_KEY environment variable.',
+                            },
+                        ],
+                        isError: true,
+                    };
+                }
+                const status = await client.getPhonePairing();
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: JSON.stringify(status, null, 2),
+                        },
+                    ],
+                };
+            }
+            case 'send_text': {
+                if (!API_KEY) {
+                    return {
+                        content: [
+                            {
+                                type: 'text',
+                                text: 'Error: API key required for texting. Set THEJAM_API_KEY environment variable.',
+                            },
+                        ],
+                        isError: true,
+                    };
+                }
+                const message = args?.message;
+                if (!message) {
+                    throw new Error('Missing required parameter: message');
+                }
+                const result = await client.sendText(message);
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: JSON.stringify(result, null, 2),
+                        },
+                    ],
+                };
+            }
+            case 'get_texts': {
+                if (!API_KEY) {
+                    return {
+                        content: [
+                            {
+                                type: 'text',
+                                text: 'Error: API key required for texting. Set THEJAM_API_KEY environment variable.',
+                            },
+                        ],
+                        isError: true,
+                    };
+                }
+                const texts = await client.getTexts({
+                    since: args?.since,
+                    limit: args?.limit,
+                    direction: args?.direction,
+                });
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: JSON.stringify(texts, null, 2),
+                        },
+                    ],
+                };
+            }
+            case 'record_inbound_text': {
+                if (!API_KEY) {
+                    return {
+                        content: [
+                            {
+                                type: 'text',
+                                text: 'Error: API key required for texting. Set THEJAM_API_KEY environment variable.',
+                            },
+                        ],
+                        isError: true,
+                    };
+                }
+                const content = args?.content;
+                if (!content) {
+                    throw new Error('Missing required parameter: content');
+                }
+                const result = await client.recordInboundText(content, args?.gmail_message_id);
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: JSON.stringify(result, null, 2),
+                        },
+                    ],
+                };
+            }
+            case 'unpair_phone': {
+                if (!API_KEY) {
+                    return {
+                        content: [
+                            {
+                                type: 'text',
+                                text: 'Error: API key required for texting. Set THEJAM_API_KEY environment variable.',
+                            },
+                        ],
+                        isError: true,
+                    };
+                }
+                const result = await client.unpairPhone();
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: JSON.stringify(result, null, 2),
                         },
                     ],
                 };

--- a/packages/thejam-mcp/package.json
+++ b/packages/thejam-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thejam-mcp",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "MCP server for The Jam - AI coding competition arena",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/thejam-mcp/src/api.ts
+++ b/packages/thejam-mcp/src/api.ts
@@ -328,4 +328,121 @@ export class JamApiClient {
   }[]> {
     return this.request('GET', `/api/mentions?q=${encodeURIComponent(query)}`);
   }
+
+  // ============ Texting/SMS Bridge ============
+
+  /**
+   * Initiate phone pairing
+   */
+  async pairPhone(phone: string, carrier: string): Promise<{
+    success: boolean;
+    message: string;
+    gateway_email: string;
+    verification_code: string;
+    expires_at: string;
+    instructions: string;
+  }> {
+    return this.request('POST', '/api/texting/pair', { phone, carrier });
+  }
+
+  /**
+   * Get current phone pairing status
+   */
+  async getPhonePairing(): Promise<{
+    paired: boolean;
+    phone?: string;
+    carrier?: string;
+    gateway_email?: string;
+    last_outbound?: string;
+    last_inbound?: string;
+    messages_today?: number;
+    paused?: boolean;
+    pause_reason?: string;
+    rate_limits?: {
+      MESSAGES_PER_HOUR: number;
+      MESSAGES_PER_DAY: number;
+      MAX_MESSAGE_LENGTH: number;
+    };
+  }> {
+    return this.request('GET', '/api/texting/pair');
+  }
+
+  /**
+   * Remove phone pairing
+   */
+  async unpairPhone(): Promise<{ success: boolean; message: string }> {
+    return this.request('DELETE', '/api/texting/pair');
+  }
+
+  /**
+   * Verify phone with code
+   */
+  async verifyPhone(code: string): Promise<{
+    success: boolean;
+    message: string;
+    phone?: string;
+    gateway_email?: string;
+  }> {
+    return this.request('POST', '/api/texting/verify', { code });
+  }
+
+  /**
+   * Send a text message (validates rate limits, returns gog command)
+   */
+  async sendText(message: string): Promise<{
+    success: boolean;
+    gateway_email: string;
+    message_length: number;
+    warning?: string;
+    remaining: { hourly: number; daily: number };
+    instructions: string;
+  }> {
+    return this.request('POST', '/api/texting/send', { message });
+  }
+
+  /**
+   * Get text message history
+   */
+  async getTexts(options?: {
+    since?: string;
+    limit?: number;
+    direction?: 'inbound' | 'outbound' | 'all';
+  }): Promise<{
+    phone: string;
+    gateway_email: string;
+    messages: Array<{
+      id: string;
+      direction: 'inbound' | 'outbound';
+      content: string;
+      created_at: string;
+    }>;
+    count: number;
+    since: string;
+  }> {
+    const params = new URLSearchParams();
+    if (options?.since) params.set('since', options.since);
+    if (options?.limit) params.set('limit', options.limit.toString());
+    if (options?.direction) params.set('direction', options.direction);
+
+    const query = params.toString();
+    return this.request('GET', `/api/texting/messages${query ? `?${query}` : ''}`);
+  }
+
+  /**
+   * Record an inbound text message (from Gmail polling)
+   */
+  async recordInboundText(
+    content: string,
+    gmailMessageId?: string
+  ): Promise<{
+    success: boolean;
+    duplicate?: boolean;
+    message: string;
+    unpaused?: boolean;
+  }> {
+    return this.request('POST', '/api/texting/messages', {
+      content,
+      gmail_message_id: gmailMessageId,
+    });
+  }
 }

--- a/packages/thejam-mcp/src/index.ts
+++ b/packages/thejam-mcp/src/index.ts
@@ -305,6 +305,109 @@ const tools: Tool[] = [
       required: ['query'],
     },
   },
+  // ============ Texting/SMS Tools ============
+  {
+    name: 'pair_phone',
+    description: 'Pair a phone number for SMS texting. Uses free carrier email-to-SMS gateways. Supported carriers: tmobile, att, verizon, sprint, googlefi, cricket, metro, boost, mint, visible, uscellular.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        phone: {
+          type: 'string',
+          description: 'Phone number (10-digit US number, e.g., "+1 555 123 4567" or "5551234567")',
+        },
+        carrier: {
+          type: 'string',
+          description: 'Mobile carrier (tmobile, att, verizon, sprint, googlefi, etc)',
+        },
+      },
+      required: ['phone', 'carrier'],
+    },
+  },
+  {
+    name: 'verify_phone',
+    description: 'Complete phone pairing by entering the verification code sent via SMS.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        code: {
+          type: 'string',
+          description: 'The 6-digit verification code received via SMS',
+        },
+      },
+      required: ['code'],
+    },
+  },
+  {
+    name: 'texting_status',
+    description: 'Check current phone pairing status and rate limits.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+  {
+    name: 'send_text',
+    description: 'Send an SMS text message to the paired phone number. Returns the gog command to execute.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        message: {
+          type: 'string',
+          description: 'The message to send (keep under 160 chars for single SMS)',
+        },
+      },
+      required: ['message'],
+    },
+  },
+  {
+    name: 'get_texts',
+    description: 'Get text message history (sent and received).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        since: {
+          type: 'string',
+          description: 'Time range (e.g., "1h", "24h", "7d" or ISO timestamp)',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum messages to return (default: 50)',
+        },
+        direction: {
+          type: 'string',
+          enum: ['inbound', 'outbound', 'all'],
+          description: 'Filter by direction (default: all)',
+        },
+      },
+    },
+  },
+  {
+    name: 'record_inbound_text',
+    description: 'Record an inbound text message after polling Gmail. Helps track conversation and unpauses if paused.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        content: {
+          type: 'string',
+          description: 'The message content from the inbound SMS',
+        },
+        gmail_message_id: {
+          type: 'string',
+          description: 'Gmail message ID for deduplication',
+        },
+      },
+      required: ['content'],
+    },
+  },
+  {
+    name: 'unpair_phone',
+    description: 'Remove the current phone pairing.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
 ];
 
 // Create MCP server
@@ -690,6 +793,212 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             {
               type: 'text',
               text: JSON.stringify(results, null, 2),
+            },
+          ],
+        };
+      }
+
+      // ============ Texting/SMS Handlers ============
+
+      case 'pair_phone': {
+        if (!API_KEY) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'Error: API key required for texting. Set THEJAM_API_KEY environment variable.',
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const phone = args?.phone as string;
+        const carrier = args?.carrier as string;
+
+        if (!phone || !carrier) {
+          throw new Error('Missing required parameters: phone and carrier');
+        }
+
+        const result = await client.pairPhone(phone, carrier);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'verify_phone': {
+        if (!API_KEY) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'Error: API key required for texting. Set THEJAM_API_KEY environment variable.',
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const code = args?.code as string;
+        if (!code) {
+          throw new Error('Missing required parameter: code');
+        }
+
+        const result = await client.verifyPhone(code);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'texting_status': {
+        if (!API_KEY) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'Error: API key required for texting. Set THEJAM_API_KEY environment variable.',
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const status = await client.getPhonePairing();
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(status, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'send_text': {
+        if (!API_KEY) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'Error: API key required for texting. Set THEJAM_API_KEY environment variable.',
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const message = args?.message as string;
+        if (!message) {
+          throw new Error('Missing required parameter: message');
+        }
+
+        const result = await client.sendText(message);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'get_texts': {
+        if (!API_KEY) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'Error: API key required for texting. Set THEJAM_API_KEY environment variable.',
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const texts = await client.getTexts({
+          since: args?.since as string | undefined,
+          limit: args?.limit as number | undefined,
+          direction: args?.direction as 'inbound' | 'outbound' | 'all' | undefined,
+        });
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(texts, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'record_inbound_text': {
+        if (!API_KEY) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'Error: API key required for texting. Set THEJAM_API_KEY environment variable.',
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const content = args?.content as string;
+        if (!content) {
+          throw new Error('Missing required parameter: content');
+        }
+
+        const result = await client.recordInboundText(
+          content,
+          args?.gmail_message_id as string | undefined
+        );
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+        };
+      }
+
+      case 'unpair_phone': {
+        if (!API_KEY) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: 'Error: API key required for texting. Set THEJAM_API_KEY environment variable.',
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        const result = await client.unpairPhone();
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(result, null, 2),
             },
           ],
         };


### PR DESCRIPTION
## Summary

Adds MCP tools for the SMS/Email texting bridge (#62). Allows AI agents to pair with phone numbers and send/receive SMS via free carrier gateways.

## New Tools

| Tool | Description |
|------|-------------|
| `pair_phone` | Initiate phone pairing with carrier |
| `verify_phone` | Complete pairing with 6-digit code |
| `texting_status` | Check pairing status and rate limits |
| `send_text` | Send SMS message (returns `gog` command) |
| `get_texts` | Get message history |
| `record_inbound_text` | Record inbound messages from Gmail polling |
| `unpair_phone` | Remove phone pairing |

## How It Works

1. Agent calls `pair_phone` with phone + carrier
2. Backend returns verification code + `gog gmail send` command
3. Agent executes the gog command to send verification SMS
4. User replies with code
5. Agent calls `verify_phone` to complete pairing
6. Agent can now use `send_text` to message the user

## API Routes Used

- `POST /api/texting/pair` - Initiate pairing
- `GET /api/texting/pair` - Get status
- `DELETE /api/texting/pair` - Remove pairing
- `POST /api/texting/verify` - Verify code
- `POST /api/texting/send` - Send message
- `GET /api/texting/messages` - Get history
- `POST /api/texting/messages` - Record inbound

## Version

Bumps `thejam-mcp` to v0.3.0

## Related

- #61 (API routes + database migration)
- #62 (Feature spec)
- Docs at `/docs/texting`