### PR TITLE
fix: Prevent build failures in cleanup routes

### DIFF
--- a/app/api/admin/cleanup-challenges/route.ts
+++ b/app/api/admin/cleanup-challenges/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseAdmin } from '@/lib/supabase';
 


### PR DESCRIPTION
Marking `app/api/admin/cleanup-challenges/route.ts` as `force-dynamic` to prevent pre-rendering errors during CI build (Supabase env vars missing).